### PR TITLE
Not interfere with other autoloader classes

### DIFF
--- a/init.php
+++ b/init.php
@@ -64,7 +64,12 @@ class Init
             false !== strpos($classname, 'Zend_'))
         {
             $classpath = str_replace('_', '/', $classname) . '.php';
-            require_once $classpath;
+
+	        // If the file exists, let's include it
+	        if(file_exists($classpath))
+	        {
+		        require_once $classpath;
+	        }
         }
     }
 


### PR DESCRIPTION
This pull request solves an issue if other autoloader classes/methods are involved in the process of loading a class if the class_exists method is being called. 