### PR TITLE
Fixed double quotes bug

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -13,8 +13,8 @@ format=json
 debug=1
 
 ;; your api public and secret keys
-api_key=""
-private_key=""
+api_key=''
+private_key=''
 
 ;; useragent
 ;; an optional user-agent string to use when calling the API


### PR DESCRIPTION
In case of double quotes, if the key contains $ symbol then it is resolved as a variable resulting in errors. For example:

![screen shot 2015-05-20 at 10 47 53 am](https://cloud.githubusercontent.com/assets/3061095/7719374/150b7628-fede-11e4-99f7-a5fc27055c38.png)

The above error arouse because of double quotes. Changing it to single quotes fixes the issue.