### PR TITLE
Replaced deprecated iconv_set_encoding with ini_set

### DIFF
--- a/libs/Zend/Validate/Hostname.php
+++ b/libs/Zend/Validate/Hostname.php
@@ -510,8 +510,8 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
         if ((count($domainParts) > 1) && (strlen($value) >= 4) && (strlen($value) <= 254)) {
             $status = false;
 
-            $origenc = iconv_get_encoding('internal_encoding');
-            iconv_set_encoding('internal_encoding', 'UTF-8');
+            $origenc = ini_get('default_charset');
+			ini_set('default_charset', 'UTF-8');
             do {
                 // First check TLD
                 $matches = array();
@@ -607,7 +607,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                 }
             } while (false);
 
-            iconv_set_encoding('internal_encoding', $origenc);
+			ini_set('default_charset', $origenc);
             // If the input passes as an Internet domain name, and domain names are allowed, then the hostname
             // passes validation
             if ($status && ($this->_options['allow'] & self::ALLOW_DNS)) {

--- a/libs/Zend/Validate/StringLength.php
+++ b/libs/Zend/Validate/StringLength.php
@@ -200,13 +200,13 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
     {
         if ($encoding !== null) {
             $orig   = iconv_get_encoding('internal_encoding');
-            $result = iconv_set_encoding('internal_encoding', $encoding);
+            $result = ini_set('default_charset', $encoding);
             if (!$result) {
                 require_once 'Zend/Validate/Exception.php';
                 throw new Zend_Validate_Exception('Given encoding not supported on this OS!');
             }
 
-            iconv_set_encoding('internal_encoding', $orig);
+            ini_set('default_charset', $orig);
         }
 
         $this->_encoding = $encoding;


### PR DESCRIPTION
iconv_set_encoding is deprecated and is resulting in the following errors on execution:

![screen shot 2015-05-22 at 2 45 29 pm](https://cloud.githubusercontent.com/assets/3061095/7767582/56087400-0091-11e5-8865-047e6e0a8ca3.png)

This PR fixes the issue.