### PR TITLE
Fixed API endpoint name to call (typo)

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -183,7 +183,7 @@ class Job extends ApproveRejectValidator
 
         $id = $this->getID($id, 'job_id');
 
-        return $this->storeResponse(Client::put('v2/translate/jobs/'.$id, $params));
+        return $this->storeResponse(Client::put('v2/translate/job/'.$id, $params));
     } //end archive()
 
     /**

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -71,7 +71,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception if no API key is set.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage No API key is set
      */
     public function testThrowsExceptionIfNoApiKeyIsSet()
@@ -84,7 +84,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception if no private key is set.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage No private key is set
      *
      * @requiredconst GENGO_PUBKEY "pubkeyfortests" Gengo test public key
@@ -100,7 +100,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to retrieve a response before making a request.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage A valid response is not yet available, please make a request first
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -66,7 +66,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test different response formats.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid response format wrong_format, accepted formats are: xml or json
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
@@ -95,7 +95,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to set wrong API key.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid API key
      */
     public function testRefusesToAcceptWrongApiKey()
@@ -107,7 +107,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to set wrong private key.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid private key
      */
     public function testRefusesToAcceptWrongPrivateKey()
@@ -146,7 +146,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test that exception is thrown if no job and revision IDs are preconfigured and job API call is made without job/revision ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage ID job_id is not set
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
@@ -166,7 +166,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test refusal to accept wrong job ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid job ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredJobId()
@@ -178,7 +178,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test refusal to accept wrong revision ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid revision ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredRevisionId()

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -142,7 +142,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "comment" is required
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -237,7 +237,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job should contain a valid rating
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -273,7 +273,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job must contain a valid reason
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -291,7 +291,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage if set, job should contain a valid follow up
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -309,7 +309,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job must contain a reason, a comment and a captcha
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -370,7 +370,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage must contain a valid "body" parameter as the comment
      *
      * @depends testAllowsToPostNewOrderWithNewJobs

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -122,7 +122,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test validation of url_attachments.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment must be an array
      */
     public function testChecksVaildityOfUrlAttachments()
@@ -152,7 +152,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must point to proper http(s) resource.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment must point to public URL with http(s) scheme
      */
     public function testRequiresUrlAttachmentsToPointToHttpResource()
@@ -188,7 +188,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must have filename.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment filename must be specified
      */
     public function testRequiresUrlAttachmentsToHaveFileName()
@@ -224,7 +224,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must have MIME type.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment MIME type must be specified
      */
     public function testRequiresUrlAttachmentsToHaveMimeType()
@@ -282,7 +282,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong status is provided.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "status" must contain a valid status
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongStatusIsProvided()
@@ -296,7 +296,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong time stamp is provided.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "timestampafter" must be non-negative integer
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongTimeStampIsProvided()
@@ -310,7 +310,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong count requested.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "count" must be integer in range between 1 and 200
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongCountRequested()
@@ -472,7 +472,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "comment" is required
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
@@ -495,7 +495,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage All jobs require job_id field
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
@@ -518,7 +518,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid job_id supplied
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -130,7 +130,7 @@ class OrderTest extends PHPUnit_Framework_TestCase
      * @param int $orderid Order ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage must contain a valid "body" parameter as the comment
      *
      * @depends testAllowsToPostNewJobs

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -147,7 +147,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter is missing.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is missing file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsMissing()
@@ -172,7 +172,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter is invalid.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is not a valid file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsInvalid()
@@ -198,7 +198,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter does not have corresponding record in files array.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is missing in filepath array
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterDoesNotHaveCorrespondingRecordInFilesArray()
@@ -224,7 +224,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file specified in file array does not exist.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Could not find file
      */
     public function testRefusesToProvideQuotationIfFileSpecifiedInFileArrayDoesNotExist()


### PR DESCRIPTION
Due to change of behavior of Jobs API phpunit run now yields:

```
There was 1 failure:
 1) Gengo\Tests\JobTest::testArchivesApprovedJob
 Failed asserting that '{"opstat":"error","err":{"code":2055,"msg":"\"job_ids\" is a required field"}}' contains "Bad Request".

```

Apparently I made a mistake (and missed it due to sandbox failure for this call) and called Jobs API instead of Job API.

Also new php-cs-fixer apparently demands namespaced @expectedException in phpunit tests - added \ where needed