### PR TITLE
Upgraded to PHPUnit 5.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [3.0.2] - 28 January 2017
+### Changed
+- upgraded tests to PHPUnit 5.7
+- PHPUnit now has new best practice for exception testing: instead of @expectedException annotation in docblock 
+  use of $this->expectException() and relevant methods is preferred
+- replaced @requiredconst annotation with @internalconst annotation: not applicable in tests
+
 ## [3.0.1] - 04 October 2016
 ### Changed
 - cleaned up composer.json

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - PHPUnit now has new best practice for exception testing: instead of @expectedException annotation in docblock 
   use of $this->expectException() and relevant methods is preferred
 - replaced @requiredconst annotation with @internalconst annotation: not applicable in tests
+- updated version number in useragent string
 
 ## [3.0.1] - 04 October 2016
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sebastian/phpcpd": "^2.0",
         "phpdocumentor/phpdocumentor": "^2.9",
         "mamuz/php-dependency-analysis": "^0.6",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.7",
         "friendsofphp/php-cs-fixer": "^1.0",
         "logics/codesniffer": "^0.1",
         "logics/configgenerator": "^0.1",

--- a/src/Client.php
+++ b/src/Client.php
@@ -153,7 +153,7 @@ class Client
      * @untranslatable api_key
      * @untranslatable private_key
      * @untranslatable Content-Type
-     * @untranslatable Gengo PHP Library; Version 3.0.0; http://gengo.com/
+     * @untranslatable Gengo PHP Library; Version 3.0.2; http://gengo.com/
      * @untranslatable timeout
      * @untranslatable application/x-www-form-urlencoded
      *
@@ -174,7 +174,7 @@ class Client
         if (self::$http instanceof HTTPclient === false) {
             $config = array(
                    'maxredirects' => 1,
-                   'useragent' => 'Gengo PHP Library; Version 3.0.0; http://gengo.com/',
+                   'useragent' => 'Gengo PHP Library; Version 3.0.2; http://gengo.com/',
                    'timeout' => Config::get('timeout'),
                    'keepalive' => false,
                   );

--- a/src/Job.php
+++ b/src/Job.php
@@ -183,7 +183,7 @@ class Job extends ApproveRejectValidator
 
         $id = $this->getID($id, 'job_id');
 
-        return $this->storeResponse(Client::put('v2/translate/jobs/'.$id, $params));
+        return $this->storeResponse(Client::put('v2/translate/job/'.$id, $params));
     } //end archive()
 
     /**

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -73,7 +73,7 @@ class APITest extends PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionIfNoApiKeyIsSet()
     {
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('No API key is set');
         $accountAPI = new Account();
         unset($accountAPI);
@@ -88,7 +88,7 @@ class APITest extends PHPUnit_Framework_TestCase
     public function testThrowsExceptionIfNoPrivateKeyIsSet()
     {
         Config::setAPIkey(GENGO_PUBKEY);
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('No private key is set');
         $accountAPI = new Account();
         unset($accountAPI);
@@ -108,7 +108,7 @@ class APITest extends PHPUnit_Framework_TestCase
 
         $accountAPI = new Account();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('A valid response is not yet available, please make a request first');
         $body = $accountAPI->getResponseBody();
         unset($body);

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -71,7 +71,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception if no API key is set.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage No API key is set
      */
     public function testThrowsExceptionIfNoApiKeyIsSet()
@@ -84,7 +84,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception if no private key is set.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage No private key is set
      *
      * @requiredconst GENGO_PUBKEY "pubkeyfortests" Gengo test public key
@@ -100,7 +100,7 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to retrieve a response before making a request.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage A valid response is not yet available, please make a request first
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Account;
 use Gengo\Config;
 use PHPUnit_Framework_TestCase;
@@ -45,8 +46,8 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test ability to retrieve response body, response code and response headers.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testProvidesResponseBodyAlongWithResponseCodeAndResponseHeaders()
     {
@@ -69,13 +70,11 @@ class APITest extends PHPUnit_Framework_TestCase
 
     /**
      * Test exception if no API key is set.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage No API key is set
      */
     public function testThrowsExceptionIfNoApiKeyIsSet()
     {
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('No API key is set');
         $accountAPI = new Account();
         unset($accountAPI);
     } //end testThrowsExceptionIfNoApiKeyIsSet()
@@ -84,14 +83,13 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception if no private key is set.
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage No private key is set
-     *
-     * @requiredconst GENGO_PUBKEY "pubkeyfortests" Gengo test public key
+     * @internalconst GENGO_PUBKEY "pubkeyfortests" Gengo test public key
      */
     public function testThrowsExceptionIfNoPrivateKeyIsSet()
     {
         Config::setAPIkey(GENGO_PUBKEY);
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('No private key is set');
         $accountAPI = new Account();
         unset($accountAPI);
     } //end testThrowsExceptionIfNoPrivateKeyIsSet()
@@ -100,11 +98,8 @@ class APITest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to retrieve a response before making a request.
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage A valid response is not yet available, please make a request first
-     *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testThrowsExceptionOnAttemptToRetrieveAResponseBeforeMakingARequest()
     {
@@ -113,6 +108,8 @@ class APITest extends PHPUnit_Framework_TestCase
 
         $accountAPI = new Account();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('A valid response is not yet available, please make a request first');
         $body = $accountAPI->getResponseBody();
         unset($body);
     } //end testThrowsExceptionOnAttemptToRetrieveAResponseBeforeMakingARequest()

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -41,8 +41,8 @@ class AccountTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -66,7 +66,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test different response formats.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid response format wrong_format, accepted formats are: xml or json
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
@@ -95,7 +95,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to set wrong API key.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid API key
      */
     public function testRefusesToAcceptWrongApiKey()
@@ -107,7 +107,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test exception on attempt to set wrong private key.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid private key
      */
     public function testRefusesToAcceptWrongPrivateKey()
@@ -146,7 +146,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test that exception is thrown if no job and revision IDs are preconfigured and job API call is made without job/revision ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage ID job_id is not set
      *
      * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
@@ -166,7 +166,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test refusal to accept wrong job ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid job ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredJobId()
@@ -178,7 +178,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test refusal to accept wrong revision ID.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid revision ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredRevisionId()

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Config;
 use Gengo\Job;
 use PHPUnit_Framework_TestCase;
@@ -45,8 +46,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Error is expected as we do not have production keys
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testProvidesEasyWayToSwitchToGengoProductionServer()
     {
@@ -66,11 +67,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test different response formats.
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid response format wrong_format, accepted formats are: xml or json
-     *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testAllowsSelectionOfResponseFormatAsJsonOrXml()
     {
@@ -88,30 +86,28 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(simplexml_load_string($jobAPI->getJob(1)) !== false);
         libxml_use_internal_errors(false);
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid response format wrong_format, accepted formats are: xml or json');
         Config::setResponseFormat('wrong_format');
     } //end testAllowsSelectionOfResponseFormatAsJsonOrXml()
 
     /**
      * Test exception on attempt to set wrong API key.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid API key
      */
     public function testRefusesToAcceptWrongApiKey()
     {
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid API key');
         Config::setAPIkey(123);
     } //end testRefusesToAcceptWrongApiKey()
 
     /**
      * Test exception on attempt to set wrong private key.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid private key
      */
     public function testRefusesToAcceptWrongPrivateKey()
     {
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid private key');
         Config::setPrivateKey(123);
     } //end testRefusesToAcceptWrongPrivateKey()
 
@@ -127,8 +123,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Clearly it is broken JSON and therefore we will assert against string only.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testAllowsToPreconfigureJobAndRevisionIdsForUseWithSubsequentJobApiCalls()
     {
@@ -146,11 +142,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      * Test that exception is thrown if no job and revision IDs are preconfigured and job API call is made without job/revision ID.
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage ID job_id is not set
-     *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function testExceptionIsThrownIfJobOrRevisionIdsAreNotPreconfiguredAndJobApiCallIsMadeWithoutThem()
     {
@@ -159,30 +152,28 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('ID job_id is not set');
         $jobAPI->getRevision();
     } //end testExceptionIsThrownIfJobOrRevisionIdsAreNotPreconfiguredAndJobApiCallIsMadeWithoutThem()
 
     /**
      * Test refusal to accept wrong job ID.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid job ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredJobId()
     {
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid job ID');
         Config::setJobID('wrong_id');
     } //end testRefusesToAcceptInvalidPreconfiguredJobId()
 
     /**
      * Test refusal to accept wrong revision ID.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid revision ID
      */
     public function testRefusesToAcceptInvalidPreconfiguredRevisionId()
     {
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid revision ID');
         Config::setRevisionID('wrong_id');
     } //end testRefusesToAcceptInvalidPreconfiguredRevisionId()
 } //end class

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -86,7 +86,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(simplexml_load_string($jobAPI->getJob(1)) !== false);
         libxml_use_internal_errors(false);
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid response format wrong_format, accepted formats are: xml or json');
         Config::setResponseFormat('wrong_format');
     } //end testAllowsSelectionOfResponseFormatAsJsonOrXml()
@@ -96,7 +96,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRefusesToAcceptWrongApiKey()
     {
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid API key');
         Config::setAPIkey(123);
     } //end testRefusesToAcceptWrongApiKey()
@@ -106,7 +106,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRefusesToAcceptWrongPrivateKey()
     {
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid private key');
         Config::setPrivateKey(123);
     } //end testRefusesToAcceptWrongPrivateKey()
@@ -152,7 +152,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('ID job_id is not set');
         $jobAPI->getRevision();
     } //end testExceptionIsThrownIfJobOrRevisionIdsAreNotPreconfiguredAndJobApiCallIsMadeWithoutThem()
@@ -162,7 +162,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRefusesToAcceptInvalidPreconfiguredJobId()
     {
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid job ID');
         Config::setJobID('wrong_id');
     } //end testRefusesToAcceptInvalidPreconfiguredJobId()
@@ -172,7 +172,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testRefusesToAcceptInvalidPreconfiguredRevisionId()
     {
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid revision ID');
         Config::setRevisionID('wrong_id');
     } //end testRefusesToAcceptInvalidPreconfiguredRevisionId()

--- a/tests/GlossaryTest.php
+++ b/tests/GlossaryTest.php
@@ -41,8 +41,8 @@ class GlossaryTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -142,7 +142,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "comment" is required
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -237,7 +237,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job should contain a valid rating
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -273,7 +273,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job must contain a valid reason
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -291,7 +291,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage if set, job should contain a valid follow up
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -309,7 +309,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage job must contain a reason, a comment and a captcha
      *
      * @depends testAllowsToPostNewOrderWithNewJobs
@@ -370,7 +370,7 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage must contain a valid "body" parameter as the comment
      *
      * @depends testAllowsToPostNewOrderWithNewJobs

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -149,7 +149,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('"comment" is required');
         $jobAPI->revise($jobid, '');
     } //end testRefusesToReturnAJobToTheTranslatorWithoutAComment()
@@ -243,7 +243,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('job should contain a valid rating');
         $jobAPI->approve($jobid, array('rating' => 0));
     } //end testRefusesToApproveAJobWithInvalidRating()
@@ -278,7 +278,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('job must contain a valid reason');
         $jobAPI->reject($jobid, array('reason' => 'wrong_reason', 'comment' => 'comment', 'captcha' => 'captcha'));
     } //end testRefusesToRejectTheTranslationWithWrongReason()
@@ -295,7 +295,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('if set, job should contain a valid follow up');
         $jobAPI->reject($jobid, array('reason' => 'other', 'comment' => 'comment', 'captcha' => 'captcha', 'follow_up' => 'wrong_followup'));
     } //end testRefusesToRejectTheTranslationWithWrongFollowUp()
@@ -312,7 +312,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('job must contain a reason, a comment and a captcha');
         $jobAPI->reject($jobid, array());
     } //end testRefusesToRejectTheTranslationWithWrongArguments()
@@ -372,7 +372,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('must contain a valid "body" parameter as the comment');
         $jobAPI->postComment($jobid, '');
     } //end testRefusesToPostEmptyCommentToJobCommentThread()

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Config;
 use Gengo\Job;
 use Gengo\Jobs;
@@ -43,8 +44,8 @@ class JobTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {
@@ -142,15 +143,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage "comment" is required
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToReturnAJobToTheTranslatorWithoutAComment($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('"comment" is required');
         $jobAPI->revise($jobid, '');
     } //end testRefusesToReturnAJobToTheTranslatorWithoutAComment()
 
@@ -237,15 +237,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage job should contain a valid rating
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToApproveAJobWithInvalidRating($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('job should contain a valid rating');
         $jobAPI->approve($jobid, array('rating' => 0));
     } //end testRefusesToApproveAJobWithInvalidRating()
 
@@ -273,15 +272,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage job must contain a valid reason
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToRejectTheTranslationWithWrongReason($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('job must contain a valid reason');
         $jobAPI->reject($jobid, array('reason' => 'wrong_reason', 'comment' => 'comment', 'captcha' => 'captcha'));
     } //end testRefusesToRejectTheTranslationWithWrongReason()
 
@@ -291,15 +289,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage if set, job should contain a valid follow up
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToRejectTheTranslationWithWrongFollowUp($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('if set, job should contain a valid follow up');
         $jobAPI->reject($jobid, array('reason' => 'other', 'comment' => 'comment', 'captcha' => 'captcha', 'follow_up' => 'wrong_followup'));
     } //end testRefusesToRejectTheTranslationWithWrongFollowUp()
 
@@ -309,15 +306,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage job must contain a reason, a comment and a captcha
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToRejectTheTranslationWithWrongArguments($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('job must contain a reason, a comment and a captcha');
         $jobAPI->reject($jobid, array());
     } //end testRefusesToRejectTheTranslationWithWrongArguments()
 
@@ -370,15 +366,14 @@ class JobTest extends PHPUnit_Framework_TestCase
      * @param int $jobid Job ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage must contain a valid "body" parameter as the comment
-     *
      * @depends testAllowsToPostNewOrderWithNewJobs
      */
     public function testRefusesToPostEmptyCommentToJobCommentThread($jobid)
     {
         $jobAPI = new Job();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('must contain a valid "body" parameter as the comment');
         $jobAPI->postComment($jobid, '');
     } //end testRefusesToPostEmptyCommentToJobCommentThread()
 

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -122,7 +122,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test validation of url_attachments.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment must be an array
      */
     public function testChecksVaildityOfUrlAttachments()
@@ -152,7 +152,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must point to proper http(s) resource.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment must point to public URL with http(s) scheme
      */
     public function testRequiresUrlAttachmentsToPointToHttpResource()
@@ -188,7 +188,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must have filename.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment filename must be specified
      */
     public function testRequiresUrlAttachmentsToHaveFileName()
@@ -224,7 +224,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test that url_attachments must have MIME type.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage URL attachment MIME type must be specified
      */
     public function testRequiresUrlAttachmentsToHaveMimeType()
@@ -282,7 +282,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong status is provided.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "status" must contain a valid status
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongStatusIsProvided()
@@ -296,7 +296,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong time stamp is provided.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "timestampafter" must be non-negative integer
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongTimeStampIsProvided()
@@ -310,7 +310,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Test refusal to retrieve a list of resources for the most recent job if wrong count requested.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "count" must be integer in range between 1 and 200
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongCountRequested()
@@ -472,7 +472,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage "comment" is required
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
@@ -495,7 +495,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage All jobs require job_id field
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
@@ -518,7 +518,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Invalid job_id supplied
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Config;
 use Gengo\Jobs;
 use Gengo\Service;
@@ -42,8 +43,8 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {
@@ -120,10 +121,6 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test validation of url_attachments.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage URL attachment must be an array
      */
     public function testChecksVaildityOfUrlAttachments()
     {
@@ -145,15 +142,13 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('URL attachment must be an array');
         $jobsAPI->postJobs($jobs);
     } //end testChecksVaildityOfUrlAttachments()
 
     /**
      * Test that url_attachments must point to proper http(s) resource.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage URL attachment must point to public URL with http(s) scheme
      */
     public function testRequiresUrlAttachmentsToPointToHttpResource()
     {
@@ -181,15 +176,13 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('URL attachment must point to public URL with http(s) scheme');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToPointToHttpResource()
 
     /**
      * Test that url_attachments must have filename.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage URL attachment filename must be specified
      */
     public function testRequiresUrlAttachmentsToHaveFileName()
     {
@@ -217,15 +210,13 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('URL attachment filename must be specified');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToHaveFileName()
 
     /**
      * Test that url_attachments must have MIME type.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage URL attachment MIME type must be specified
      */
     public function testRequiresUrlAttachmentsToHaveMimeType()
     {
@@ -253,6 +244,8 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('URL attachment MIME type must be specified');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToHaveMimeType()
 
@@ -280,43 +273,37 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test refusal to retrieve a list of resources for the most recent job if wrong status is provided.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage "status" must contain a valid status
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongStatusIsProvided()
     {
         $jobsAPI = new Jobs();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('"status" must contain a valid status');
         $jobsAPI->getJobs('wrong_status', 0, 10);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongStatusIsProvided()
 
     /**
      * Test refusal to retrieve a list of resources for the most recent job if wrong time stamp is provided.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage "timestampafter" must be non-negative integer
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongTimeStampIsProvided()
     {
         $jobsAPI = new Jobs();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('"timestampafter" must be non-negative integer');
         $jobsAPI->getJobs('available', -100, 10);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongTimeStampIsProvided()
 
     /**
      * Test refusal to retrieve a list of resources for the most recent job if wrong count requested.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage "count" must be integer in range between 1 and 200
      */
     public function testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongCountRequested()
     {
         $jobsAPI = new Jobs();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('"count" must be integer in range between 1 and 200');
         $jobsAPI->getJobs('available', 0, 0);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongCountRequested()
 
@@ -472,9 +459,6 @@ class JobsTest extends PHPUnit_Framework_TestCase
      * @param array $jobids Job identifiers
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage "comment" is required
-     *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
      */
     public function testRefusesToReturnAJobToTheTranslatorWithoutAComment(array $jobids)
@@ -486,6 +470,8 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('"comment" is required');
         $jobsAPI->revise($jobs, '');
     } //end testRefusesToReturnAJobToTheTranslatorWithoutAComment()
 
@@ -494,9 +480,6 @@ class JobsTest extends PHPUnit_Framework_TestCase
      *
      * @param array $jobids Job identifiers
      *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage All jobs require job_id field
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
      */
@@ -509,6 +492,8 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('All jobs require job_id field');
         $jobsAPI->revise($jobs, 'test comment');
     } //end testRefusesToReturnAJobToTheTranslatorIfNoJobIdsAreSpecified()
 
@@ -517,9 +502,6 @@ class JobsTest extends PHPUnit_Framework_TestCase
      *
      * @param array $jobids Job identifiers
      *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Invalid job_id supplied
      *
      * @depends testRetrievesAListOfJobsByAListOfJobIds
      */
@@ -532,6 +514,8 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Invalid job_id supplied');
         $jobsAPI->revise($jobs, 'test comment');
     } //end testRefusesToReturnAJobToTheTranslatorIfJobIdsAreInvalid()
 

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -142,7 +142,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('URL attachment must be an array');
         $jobsAPI->postJobs($jobs);
     } //end testChecksVaildityOfUrlAttachments()
@@ -176,7 +176,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('URL attachment must point to public URL with http(s) scheme');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToPointToHttpResource()
@@ -210,7 +210,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('URL attachment filename must be specified');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToHaveFileName()
@@ -244,7 +244,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
 
         $jobs = array($job1);
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('URL attachment MIME type must be specified');
         $jobsAPI->postJobs($jobs);
     } //end testRequiresUrlAttachmentsToHaveMimeType()
@@ -278,7 +278,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
     {
         $jobsAPI = new Jobs();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('"status" must contain a valid status');
         $jobsAPI->getJobs('wrong_status', 0, 10);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongStatusIsProvided()
@@ -290,7 +290,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
     {
         $jobsAPI = new Jobs();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('"timestampafter" must be non-negative integer');
         $jobsAPI->getJobs('available', -100, 10);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongTimeStampIsProvided()
@@ -302,7 +302,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
     {
         $jobsAPI = new Jobs();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('"count" must be integer in range between 1 and 200');
         $jobsAPI->getJobs('available', 0, 0);
     } //end testRefusesToRetrieveAListOfResourcesForTheMostRecentJobsIfWrongCountRequested()
@@ -470,7 +470,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('"comment" is required');
         $jobsAPI->revise($jobs, '');
     } //end testRefusesToReturnAJobToTheTranslatorWithoutAComment()
@@ -492,7 +492,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('All jobs require job_id field');
         $jobsAPI->revise($jobs, 'test comment');
     } //end testRefusesToReturnAJobToTheTranslatorIfNoJobIdsAreSpecified()
@@ -514,7 +514,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              array('job_id' => array_shift($jobids)),
             );
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid job_id supplied');
         $jobsAPI->revise($jobs, 'test comment');
     } //end testRefusesToReturnAJobToTheTranslatorIfJobIdsAreInvalid()

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -130,7 +130,7 @@ class OrderTest extends PHPUnit_Framework_TestCase
      * @param int $orderid Order ID
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage must contain a valid "body" parameter as the comment
      *
      * @depends testAllowsToPostNewJobs

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Config;
 use Gengo\Jobs;
 use Gengo\Order;
@@ -44,8 +45,8 @@ class OrderTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {
@@ -130,15 +131,14 @@ class OrderTest extends PHPUnit_Framework_TestCase
      * @param int $orderid Order ID
      *
      *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage must contain a valid "body" parameter as the comment
-     *
      * @depends testAllowsToPostNewJobs
      */
     public function testRefusesToPostEmptyCommentToOrderCommentThread($orderid)
     {
         $orderAPI = new Order();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('must contain a valid "body" parameter as the comment');
         $orderAPI->postComment($orderid, '');
     } //end testRefusesToPostEmptyCommentToOrderCommentThread()
 

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -137,7 +137,7 @@ class OrderTest extends PHPUnit_Framework_TestCase
     {
         $orderAPI = new Order();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('must contain a valid "body" parameter as the comment');
         $orderAPI->postComment($orderid, '');
     } //end testRefusesToPostEmptyCommentToOrderCommentThread()

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -162,7 +162,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('is missing file_key parameter');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterIsMissing()
@@ -186,7 +186,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('is not a valid file_key parameter');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterIsInvalid()
@@ -210,7 +210,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('is missing in filepath array');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterDoesNotHaveCorrespondingRecordInFilesArray()
@@ -234,7 +234,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
-        $this->expectException(Exception::CLASS);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Could not find file');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileSpecifiedInFileArrayDoesNotExist()

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -8,6 +8,7 @@
 
 namespace Gengo\Tests;
 
+use Exception;
 use Gengo\Config;
 use Gengo\Service;
 use PHPUnit_Framework_TestCase;
@@ -43,8 +44,8 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Set up tests.
      *
      *
-     * @requiredconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
-     * @requiredconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
+     * @internalconst GENGO_PUBKEY  "pubkeyfortests"                               Gengo test public key
+     * @internalconst GENGO_PRIVKEY "privatekeyfortestuserthatcontainsonlyletters" Gengo test private key
      */
     public function setUp()
     {
@@ -145,10 +146,6 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test refuses to provide quotation if file_key parameter is missing.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage is missing file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsMissing()
     {
@@ -165,15 +162,13 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('is missing file_key parameter');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterIsMissing()
 
     /**
      * Test refuses to provide quotation if file_key parameter is invalid.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage is not a valid file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsInvalid()
     {
@@ -191,15 +186,13 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('is not a valid file_key parameter');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterIsInvalid()
 
     /**
      * Test refuses to provide quotation if file_key parameter does not have corresponding record in files array.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage is missing in filepath array
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterDoesNotHaveCorrespondingRecordInFilesArray()
     {
@@ -217,15 +210,13 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('is missing in filepath array');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileKeyParameterDoesNotHaveCorrespondingRecordInFilesArray()
 
     /**
      * Test refuses to provide quotation if file specified in file array does not exist.
-     *
-     *
-     * @expectedException        \Exception
-     * @expectedExceptionMessage Could not find file
      */
     public function testRefusesToProvideQuotationIfFileSpecifiedInFileArrayDoesNotExist()
     {
@@ -243,6 +234,8 @@ class ServiceTest extends PHPUnit_Framework_TestCase
 
         $serviceAPI = new Service();
 
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage('Could not find file');
         $serviceAPI->quote($jobs, $files);
     } //end testRefusesToProvideQuotationIfFileSpecifiedInFileArrayDoesNotExist()
 } //end class

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -147,7 +147,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter is missing.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is missing file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsMissing()
@@ -172,7 +172,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter is invalid.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is not a valid file_key parameter
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterIsInvalid()
@@ -198,7 +198,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file_key parameter does not have corresponding record in files array.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage is missing in filepath array
      */
     public function testRefusesToProvideQuotationIfFileKeyParameterDoesNotHaveCorrespondingRecordInFilesArray()
@@ -224,7 +224,7 @@ class ServiceTest extends PHPUnit_Framework_TestCase
      * Test refuses to provide quotation if file specified in file array does not exist.
      *
      *
-     * @expectedException        Exception
+     * @expectedException        \Exception
      * @expectedExceptionMessage Could not find file
      */
     public function testRefusesToProvideQuotationIfFileSpecifiedInFileArrayDoesNotExist()


### PR DESCRIPTION
PHPUnit now has new best practice for exception testing: instead of @expectedException annotation in docblock use of $this->expectException() and relevant methods is preferred, This allows to specify the point in the test where exception is expected instead of blanket exception expectation.

Also replaced @requiredconst annotation with @internalconst annotation since GENGO_PUBKEY and GENGO_PRIVKEY constants are not configurable and used solely in tests.

Please merge and bump version to 3.0.2