### PR TITLE
Check for potential regression due to use of ampersand in text strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [3.0.3] - 1 February 2017
+### Changed
+- test that ampersand in text strings (for comments and jobs) does not cause any issues. Thanks to Nick Ustinov.
+- updated version number in useragent string
+
 ## [3.0.2] - 28 January 2017
 ### Changed
 - upgraded tests to PHPUnit 5.7

--- a/src/Client.php
+++ b/src/Client.php
@@ -153,7 +153,7 @@ class Client
      * @untranslatable api_key
      * @untranslatable private_key
      * @untranslatable Content-Type
-     * @untranslatable Gengo PHP Library; Version 3.0.2; http://gengo.com/
+     * @untranslatable Gengo PHP Library; Version 3.0.3; http://gengo.com/
      * @untranslatable timeout
      * @untranslatable application/x-www-form-urlencoded
      *
@@ -174,7 +174,7 @@ class Client
         if (self::$http instanceof HTTPclient === false) {
             $config = array(
                    'maxredirects' => 1,
-                   'useragent' => 'Gengo PHP Library; Version 3.0.2; http://gengo.com/',
+                   'useragent' => 'Gengo PHP Library; Version 3.0.3; http://gengo.com/',
                    'timeout' => Config::get('timeout'),
                    'keepalive' => false,
                   );

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -63,7 +63,7 @@ class JobTest extends PHPUnit_Framework_TestCase
         $job1 = array(
              'type' => 'text',
              'slug' => 'API Liverpool 1',
-             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
              'lc_src' => 'en',
              'lc_tgt' => 'ja',
              'tier' => 'standard',
@@ -114,7 +114,7 @@ class JobTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('ok', $response['opstat']);
         $this->assertTrue(isset($response['response']));
         $this->assertEquals(
-            'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+            'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
             $response['response']['job']['body_src']
         );
     } //end testRetrievesASpecificJob()
@@ -355,7 +355,7 @@ class JobTest extends PHPUnit_Framework_TestCase
     {
         $jobAPI = new Job();
 
-        $response = json_decode($jobAPI->postComment($jobid, 'Test comment'), true);
+        $response = json_decode($jobAPI->postComment($jobid, 'Test comment. Johnson & Johnson'), true);
         $this->assertEquals('ok', $response['opstat']);
         $this->assertTrue(isset($response['response']));
     } //end testSubmitsANewCommentToTheJobCommentThread()
@@ -392,7 +392,7 @@ class JobTest extends PHPUnit_Framework_TestCase
         $response = json_decode($jobAPI->getComments($jobid), true);
         $this->assertEquals('ok', $response['opstat']);
         $this->assertTrue(isset($response['response']));
-        $this->assertEquals('Test comment', $response['response']['thread'][0]['body']);
+        $this->assertEquals('Test comment. Johnson & Johnson', $response['response']['thread'][0]['body']);
     } //end testRetrievesTheCommentThreadForAJob()
 
     /**

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -62,7 +62,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
         $job1 = array(
              'type' => 'text',
              'slug' => 'API Liverpool 1',
-             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
              'lc_src' => 'en',
              'lc_tgt' => 'ja',
              'tier' => 'standard',
@@ -81,7 +81,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              'type' => 'text',
              'slug' => 'API Job test',
              'body_src' => 'First test.',
-             'comment' => 'Some awsome comment here.',
+             'comment' => 'Some awsome comment here. Johnson & Johnson',
              'url_attachments' => array(
                            array(
                         'url' => 'https://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
@@ -130,7 +130,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              'type' => 'text',
              'slug' => 'API Job test',
              'body_src' => 'First test.',
-             'comment' => 'Some awsome comment here.',
+             'comment' => 'Some awsome comment here. Johnson & Johnson',
              'url_attachments' => array('bad attachment'),
              'lc_src' => 'en',
              'lc_tgt' => 'ja',
@@ -158,7 +158,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              'type' => 'text',
              'slug' => 'API Job test',
              'body_src' => 'First test.',
-             'comment' => 'Some awsome comment here.',
+             'comment' => 'Some awsome comment here. Johnson & Johnson',
              'url_attachments' => array(
                            array(
                         'url' => 'ftp://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
@@ -192,7 +192,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              'type' => 'text',
              'slug' => 'API Job test',
              'body_src' => 'First test.',
-             'comment' => 'Some awsome comment here.',
+             'comment' => 'Some awsome comment here. Johnson & Johnson',
              'url_attachments' => array(
                            array(
                         'url' => 'http://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
@@ -226,7 +226,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
              'type' => 'text',
              'slug' => 'API Job test',
              'body_src' => 'First test.',
-             'comment' => 'Some awsome comment here.',
+             'comment' => 'Some awsome comment here. Johnson & Johnson',
              'url_attachments' => array(
                            array(
                         'url' => 'http://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
@@ -365,14 +365,14 @@ class JobsTest extends PHPUnit_Framework_TestCase
         $job1 = array(
              'type' => 'file',
              'identifier' => $identifiers[0],
-             'comment' => 'Test comment',
+             'comment' => 'Test comment. Johnson & Johnson',
              'force' => true,
             );
 
         $job2 = array(
              'type' => 'file',
              'identifier' => $identifiers[1],
-             'comment' => 'Test comment',
+             'comment' => 'Test comment. Johnson & Johnson',
              'force' => true,
             );
 
@@ -662,7 +662,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
                     'job_01' => array(
                         'type' => 'text',
                         'slug' => 'API Liverpool 1',
-                        'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+                        'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
                         'lc_src' => 'en',
                         'lc_tgt' => 'ja',
                         'tier' => 'standard',
@@ -680,7 +680,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
                     'job_01' => array(
                         'type' => 'text',
                         'slug' => 'API Liverpool 1',
-                        'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+                        'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
                         'lc_src' => 'en',
                         'lc_tgt' => 'ja',
                         'tier' => 'standard',

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -64,7 +64,7 @@ class OrderTest extends PHPUnit_Framework_TestCase
         $job1 = array(
              'type' => 'text',
              'slug' => 'API Liverpool 1',
-             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside.',
+             'body_src' => 'Liverpool_1 Football Club is an English Premier League football club based in Liverpool, Merseyside. Johnson & Johnson',
              'lc_src' => 'en',
              'lc_tgt' => 'ja',
              'tier' => 'standard',


### PR DESCRIPTION
It was brought to my attention that use of ampersands in text strings may cause issues if older logics/http (<= 0.1.2) is installed. To ensure that no such regression may go unnoticed I have added ampersand to all relevant tests.

Version bump and changelog modified accordingly.