### PR TITLE
Fix getJobs parameter adding to data parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [3.0.4] - 15 March 2017
+### Changed
+- fix `getJobs` parameters not applying
+
 ## [3.0.3] - 1 February 2017
 ### Changed
 - test that ampersand in text strings (for comments and jobs) does not cause any issues. Thanks to Nick Ustinov.

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -208,9 +208,7 @@ class Jobs extends ApproveRejectValidator
             $data['count'] = $count;
         }
 
-        $params = (count($data) > 0) ? array('data' => json_encode($data)) : array();
-
-        return $this->storeResponse(Client::get('v2/translate/jobs', $params));
+        return $this->storeResponse(Client::get('v2/translate/jobs', $data));
     } //end getJobs()
 
     /**

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -284,7 +284,7 @@ class JobsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('ok', $response['opstat']);
         $this->assertTrue(isset($response['response']));
         $this->assertTrue(is_array($response['response']));
-        $this->assertEquals(count($response['response']), $expectedCount)
+        $this->assertEquals(count($response['response']), $expectedCount);
     } //end testGetJobsCount()
 
     /**

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -271,6 +271,22 @@ class JobsTest extends PHPUnit_Framework_TestCase
         return $jobids;
     } //end testRetrievesAListOfResourcesForTheMostRecentJobsFilteredByTheGivenParameters()
 
+
+    /**
+     * Test retrieval of list of resources with different count for the most recent jobs filtered by given parameters.
+     */
+    public function testGetJobsCount()
+    {
+        $expectedCount = 15;
+
+        $jobsAPI = new Jobs();
+        $response = json_decode($jobsAPI->getJobs('available', 0, $expectedCount), true);
+        $this->assertEquals('ok', $response['opstat']);
+        $this->assertTrue(isset($response['response']));
+        $this->assertTrue(is_array($response['response']));
+        $this->assertEquals(count($response['response']), $expectedCount)
+    } //end testGetJobsCount()
+
     /**
      * Test refusal to retrieve a list of resources for the most recent job if wrong status is provided.
      */

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -271,7 +271,6 @@ class JobsTest extends PHPUnit_Framework_TestCase
         return $jobids;
     } //end testRetrievesAListOfResourcesForTheMostRecentJobsFilteredByTheGivenParameters()
 
-
     /**
      * Test retrieval of list of resources with different count for the most recent jobs filtered by given parameters.
      */


### PR DESCRIPTION
## Description
- Fix `getJobs` method dont encode expected parameters

## Related Issue
- https://github.com/gengo/gengo-php/issues/51