### PR TITLE
hide debug outputs

### DIFF
--- a/libs/Gengo/Client.php
+++ b/libs/Gengo/Client.php
@@ -139,13 +139,6 @@ class Gengo_Client
         }
         try {
             $this->client->setUri($url);
-            if ($this->config->get('debug', false))
-            {
-                $response = $this->client->request($method);
-                echo $this->client->getUri(true) . "\n";
-                echo $this->client->getLastRequest() . "\n";
-                return $response;
-            }
             return $this->client->request($method);
         }
         catch (Exception $ex)


### PR DESCRIPTION
To remove debug message it's displayed on debug environment, comment out messages.

This PR won't be merged to master because current main stream version is 3.x but this is a successor of 2.1.x.